### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+on:
+  push:
+    tags: [ 'v*' ]
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+  build:
+    name: Compile
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bleep-build/bleep-setup-action@0.0.2
+      - uses: coursier/cache-action@v6
+        with:
+          extraFiles: bleep.yaml
+      - name: Compile
+        run: bleep compile
+
+  publish:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    if: "startsWith(github.ref, 'refs/tags/v')"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bleep-build/bleep-setup-action@0.0.2
+      - name: Release
+        run: bleep publish
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
This workflow triggers on pushes to the 'main' branch and tagged releases, and also includes a compile job that skips if 'ci skip' is in the commit message. An additional publish job is executed for tagged releases, using secrets for environment configuration.
