### PR TITLE
Remove redundant import in TwilioClient.scala

### DIFF
--- a/zio-messaging-twilio/src/scala/io/github/nafg/messaging/twilio/TwilioClient.scala
+++ b/zio-messaging-twilio/src/scala/io/github/nafg/messaging/twilio/TwilioClient.scala
@@ -1,13 +1,12 @@
 package io.github.nafg.messaging.twilio
 
-
 import com.twilio.http.TwilioRestClient
-import zio.{Config, ZLayer}
+import zio.ZLayer
 
 case class TwilioClient(twilioRestClient: TwilioRestClient)
 object TwilioClient {
   case class Config(accountSid: String, authToken: String)
-  
+
   val layer = ZLayer.fromFunction { (config: Config) =>
     TwilioClient(
       new TwilioRestClient.Builder(config.accountSid, config.authToken)


### PR DESCRIPTION
Eliminated unused Config import statement in TwilioClient.scala to improve code cleanliness and maintainability. No functional changes were made.
