### PR TITLE
EntranceGroupSmsService: fix still incorrect URL definition

### DIFF
--- a/zio-messaging-entrance-group/src/scala/io/github/nafg/messaging/entrancegrp/EntranceGroupSmsService.scala
+++ b/zio-messaging-entrance-group/src/scala/io/github/nafg/messaging/entrancegrp/EntranceGroupSmsService.scala
@@ -42,7 +42,7 @@ object EntranceGroupSmsService {
   }
 
   private val endpoint =
-    Endpoint(POST / "hooks" / "campaign" / long("id"))
+    Endpoint(POST / "hooks" / "campaigns" / long("id"))
       .in[RequestBody]
       .out[ResponseBody]
 


### PR DESCRIPTION
Corrected the endpoint URL from "hooks/campaign" to "hooks/campaigns"
