### PR TITLE
ci: enable automerge and add merge_group trigger in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
+  merge_group:
 
 jobs:
   build:

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
+  automerge: true,
   customManagers: [
     {
       customType: "jsonata",


### PR DESCRIPTION
Added a 'merge_group' event trigger to the GitHub Actions CI workflow to
support batch merges. Enabled automerge in renovate.json5 to allow
automatic merging of dependency updates, streamlining the update process
and reducing manual intervention.
